### PR TITLE
Change of Algorithm

### DIFF
--- a/app/api/match/route.ts
+++ b/app/api/match/route.ts
@@ -1,5 +1,5 @@
 import { db } from "@/lib/firebase";
-import { cosineSimilarityWeighted, QUIZ_WEIGHTS } from "@/lib/utils";
+import { manhattanSimilarityWeighted, QUIZ_WEIGHTS } from "@/lib/utils";
 import { collection, getDocs, query } from "firebase/firestore";
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
@@ -12,7 +12,7 @@ export async function POST(request: Request) {
 
   console.log('DEBUG answers:', data, 'len=', Array.isArray(data) ? data.length : 'NA');
 
-
+  
   let clubs: any[] = [];
 
   let q = query(collection(db, "clubs"));
@@ -48,7 +48,7 @@ export async function POST(request: Request) {
   const source = pool.length ? pool : validClubs; // use filtered set if any remain
   source.forEach((club) => {
     const quizClub = (club.quiz ?? []).map(Number);
-    const score = cosineSimilarityWeighted(data.map(Number), quizClub, QUIZ_WEIGHTS);
+    const score = manhattanSimilarityWeighted(data.map(Number), quizClub, QUIZ_WEIGHTS);
     similarities.push({
       email: String(club.email ?? ""),
       matchScore: Number.isFinite(score) ? score : 0, // keep in 0..1

--- a/app/api/match/route.ts
+++ b/app/api/match/route.ts
@@ -9,10 +9,8 @@ export async function POST(request: Request) {
   console.log('HIT POST /api/match');
   const data: number[] = await request.json();
 
-
   console.log('DEBUG answers:', data, 'len=', Array.isArray(data) ? data.length : 'NA');
 
-  
   let clubs: any[] = [];
 
   let q = query(collection(db, "clubs"));

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,5 @@
 // Weights for Q1..Q8 (sum ≈ 1). Tweak as you like.
-export const QUIZ_WEIGHTS: number[] = [0.25, 0.25, 0.10, 0.15, 0.03, 0.07, 0.05, 0.10];
+export const QUIZ_WEIGHTS: number[] = [0.15, 0.15, 0.13, 0.13, 0.12, 0.12, 0.10, 0.10];
 
 // Clamp helper
 const clamp01 = (x: number) => Math.max(0, Math.min(1, x));
@@ -42,6 +42,76 @@ export function cosineSimilarityWeighted(a: unknown[], b: unknown[], w: number[]
   return clamp01(denom ? dot / denom : 0);
 }
 
+/** 
+ * Weighted Manhattan Distance similarity.
+ * Returns 0..1 where 1 = perfect match, 0 = worst possible match.
+ * Better for quiz-based categorical/ordinal matching than cosine similarity.
+ */
+export function manhattanSimilarityWeighted(a: unknown[], b: unknown[], w: number[] = QUIZ_WEIGHTS) {
+  if (!Array.isArray(a) || !Array.isArray(b) || !Array.isArray(w)) return 0;
+  const n = Math.min(a.length, b.length, w.length);
+  if (n === 0) return 0;
+
+  let weightedDistance = 0;
+  let totalWeight = 0;
+
+  for (let i = 0; i < n; i++) {
+    const x = Number(a[i]);
+    const y = Number(b[i]);
+    const weight = Number(w[i]);
+    
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(weight)) continue;
+    
+    // Calculate absolute difference and apply weight
+    const distance = Math.abs(x - y) * weight;
+    weightedDistance += distance;
+    totalWeight += weight;
+  }
+
+  if (totalWeight === 0) return 0;
+
+  // Assume 1-5 scale, so max possible distance per question is 4
+  // Max weighted distance = totalWeight * 4
+  const maxPossibleDistance = totalWeight * 4;
+  
+  // Convert distance to similarity (higher = better match)
+  const similarity = 1 - (weightedDistance / maxPossibleDistance);
+  
+  return clamp01(similarity);
+}
+
+/** 
+ * Plain Manhattan Distance similarity (unweighted).
+ * Useful for comparison or when you don't want to use weights.
+ */
+export function manhattanSimilarity(a: unknown[], b: unknown[]) {
+  if (!Array.isArray(a) || !Array.isArray(b)) return 0;
+  const n = Math.min(a.length, b.length);
+  if (n === 0) return 0;
+
+  let totalDistance = 0;
+  let validPairs = 0;
+
+  for (let i = 0; i < n; i++) {
+    const x = Number(a[i]);
+    const y = Number(b[i]);
+    
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+    
+    totalDistance += Math.abs(x - y);
+    validPairs++;
+  }
+
+  if (validPairs === 0) return 0;
+
+  // Assume 1-5 scale, so max possible distance per question is 4
+  const maxPossibleDistance = validPairs * 4;
+  
+  // Convert distance to similarity
+  const similarity = 1 - (totalDistance / maxPossibleDistance);
+  
+  return clamp01(similarity);
+}
 
 // Borrowed from freeCodeCamp
 export function isValidHttpUrl(str: string) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -82,7 +82,6 @@ export function manhattanSimilarityWeighted(a: unknown[], b: unknown[], w: numbe
 
 /** 
  * Plain Manhattan Distance similarity (unweighted).
- * Useful for comparison or when you don't want to use weights.
  */
 export function manhattanSimilarity(a: unknown[], b: unknown[]) {
   if (!Array.isArray(a) || !Array.isArray(b)) return 0;


### PR DESCRIPTION
Changing the algorithm from a Cosine Similarity to The Manhattan algorithm. I made this choice since it makes more sense for The Manhattan in the context of quizzes rather than a cosine similarity algorithm.

Cosine similarity can recommend very unrelated clubs due to answers. Answers on client and club side can be very different, but the cosine similarity will still find a 99% match rate between them.

The Manhattan performs much better especially in terms of category and context of student to club answers.